### PR TITLE
Add Font Awesome to QBitTorrent custom HTTP header

### DIFF
--- a/docs/themes/qbittorrent.md
+++ b/docs/themes/qbittorrent.md
@@ -63,7 +63,7 @@ If you dont' want to remove the headers using a webserver, you can also override
 Add the following in `Add custom HTTP headers` on the `Web UI` section.
 
 ```nginx
-content-security-policy: default-src 'self'; style-src 'self' 'unsafe-inline' theme-park.dev raw.githubusercontent.com; img-src 'self' theme-park.dev raw.githubusercontent.com data:; script-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'self'; frame-ancestors 'self';
+content-security-policy: default-src 'self'; style-src 'self' 'unsafe-inline' theme-park.dev raw.githubusercontent.com use.fontawesome.com; img-src 'self' theme-park.dev raw.githubusercontent.com data:; script-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'self'; frame-ancestors 'self'; font-src use.fontawesome.com;
 ```
 
 ![](/site_assets/{{ page.title.split()[0].lower() }}/CSP.png)


### PR DESCRIPTION
To use the Font Awesome icons that are referenced in the qBittorent-base.css theme we need to add `use.fontawesome.com` as a source in `style-src` and `font-src` in the custom HTTP header in the qBittorrent Web-UI, otherwise the icons will fail to load due to CSP.

![image](https://user-images.githubusercontent.com/7003717/148595765-8f392fce-0bd2-4374-9bf9-fb17fe031b0c.png)
