### PR TITLE
Add Bitwarden CSP how-to

### DIFF
--- a/docs/themes/bitwarden.md
+++ b/docs/themes/bitwarden.md
@@ -11,6 +11,19 @@ Custom [{{ page.title.split()[0] }}](https://github.com/bitwarden) CSS
 
 ### [Setup](/setup)
 
+Due to Bitwarden's `Content-Security-Policy` header, it is necessary to adjust this policy to include the domain(s) to load stylesheets from. Open `bwdata/config.yml` and add the domain name(s) to the `nginx_header_content_security_policy` property in the `style-src` policy directive.
+
+```yaml
+...
+nginx_header_content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline' [domainnamehere]; ..."
+...
+```
+
+!!! warning "nginx_header_content_security_policy was trimmed"
+    The `nginx_header_content_security_policy` was trimmed for brevity. Adjust your own copy from Bitwarden or it might lead to unexpected results.
+
+Where `[domainnamehere]` should be replaced with `theme-park.dev raw.githubusercontent.com` or your own custom domain. This will allow stylesheets sources to load from the specified domain(s).
+
 {% set addons = extra.addons %}
 {% set title = page.title.split()[0].lower() %}
 {% for app, addon_name in addons.items() %}


### PR DESCRIPTION
The official Bitwarden docker install will not work unless its Content-Security-Policy header is adjusted.