### PR TITLE
Update pihole nginx config

### DIFF
--- a/docs/themes/pihole.md
+++ b/docs/themes/pihole.md
@@ -22,13 +22,12 @@ Custom [{{ page.title.split()[0] }}](https://github.com/pi-hole/pi-hole) CSS
 ```nginx
 proxy_set_header Accept-Encoding "";
 sub_filter
-'<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; child-src \'self\'; form-action \'self\'; frame-src \'self\'; font-src \'self\'; connect-src \'self\'; img-src \'self\'; manifest-src \'self\'; script-src \'self\' \'unsafe-inline\'; style-src \'self\' \'unsafe-inline\'">'
-'<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'none\'; child-src \'self\'; form-action \'self\'; frame-src \'self\'; font-src \'self\'; connect-src \'self\'; img-src \'self\' https://raw.githubusercontent.com; manifest-src \'self\'; script-src \'self\' \'unsafe-inline\'; style-src \'self\' https://raw.githubusercontent.com https://theme-park.dev \'unsafe-inline\'">';
-sub_filter
 '</head>'
 '<link rel="stylesheet" type="text/css" href="https://theme-park.dev/css/base/pihole/<THEME>.css">
 </head>';
 sub_filter_once on;
+proxy_hide_header Content-Security-Policy;
+add_header Content-Security-Policy "default-src 'none'; base-uri 'none'; child-src 'self'; form-action 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' https://raw.githubusercontent.com; manifest-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' https://raw.githubusercontent.com https://theme-park.dev 'unsafe-inline'";
 ```
 
 {% set addons = extra.addons %}


### PR DESCRIPTION
Update nginx config to enable loading of themes on newer Pi-hole versions

In newer installations of Pi-hole, the Content Security Policy (CSP) is no longer applied using a meta tag, but rather through HTTP headers (refer to [this link](https://github.com/pi-hole/pi-hole/pull/4862/)).

This PR introduces a modified nginx configuration to allow the injection of CSS styles for themes with these HTTP headers.
The updated nginx configuration achieves this by utilizing the following approach:
```nginx
proxy_hide_header Content-Security-Policy;
add_header Content-Security-Policy "default-src 'none'; base-uri 'none'; child-src 'self'; form-action 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' https://raw.githubusercontent.com; manifest-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' https://raw.githubusercontent.com https://theme-park.dev 'unsafe-inline'";
```
These changes remove the existing Content-Security-Policy header and add a new header with an updated policy that allows for the injection of CSS styles from the 2 required sites, while maintaining necessary security restrictions for other resources.

Thank you.